### PR TITLE
added options to xml2js for 'sleeker' json generation

### DIFF
--- a/demoEveCentral.coffee
+++ b/demoEveCentral.coffee
@@ -19,10 +19,8 @@ priceComparator = (inverse=false) ->
 
 client.fetch('quicklook', typeid: 31866, regionlimit: 10000002)
   .get('quicklook')
-  .get(0)
   .then (data) ->
-
-    regions = (for reg in data.regions[0].region
+    regions = (for reg in data.regions.region
       reg.replace(/^\s+|\s$/g, '')
     ).join(", ")
 
@@ -31,16 +29,16 @@ client.fetch('quicklook', typeid: 31866, regionlimit: 10000002)
     console.log ""
     console.log "Sell orders"
 
-    data.sell_orders[0].order.sort priceComparator()
-    data.buy_orders[0].order.sort priceComparator(true)
+    data.sell_orders.order.sort priceComparator()
+    data.buy_orders.order.sort priceComparator(true)
 
-    for so in data.sell_orders[0].order
+    for so in data.sell_orders.order
       console.log "#{so.station_name} (#{so.security}): #{so.vol_remain} items @ #{neow.format.isk(so.price)}"
 
     console.log ""
     console.log "Buy orders"
 
-    for so in data.buy_orders[0].order
+    for so in data.buy_orders.order
       console.log "#{so.station_name} (#{so.security}): #{so.vol_remain} items @ #{neow.format.isk(so.price)}"
 
   .done()

--- a/src/evecentral/parser.coffee
+++ b/src/evecentral/parser.coffee
@@ -5,6 +5,6 @@ xml2js = require 'xml2js'
 root = exports ? this
 
 root.parse = (data, strict=true) ->
-  Q.nfapply(xml2js.parseString, [data])
+  Q.nfapply(xml2js.parseString, [data, {explicitArray: false, mergeAttrs: true}])
     .get('evec_api')
 


### PR DESCRIPTION
I added some options to the xml2js call that the eve central client uses in the parser.  I normally use these options to eliminate xml2js wanting to put everything in arrays.  It helps to make the result a little more 'sane'.

I realize this may/will be a breaking change for anyone currently using the eve central client.
